### PR TITLE
VENDEDORES-599 - não exibir pedidos -3 no seller_app

### DIFF
--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -44,6 +44,7 @@
           JOIN vendas v ON vi.order_id = v.order_id
           LEFT JOIN vendas_detalhes vd ON v.order_id = vd.order_id
           WHERE v.log > DATE_SUB(NOW(), INTERVAL 6 MONTH)
+          AND v.status != -3
           GROUP BY order_id"
 
         deltaImportQuery="
@@ -81,6 +82,7 @@
            JOIN vendas v ON vi.order_id = v.order_id
            LEFT JOIN vendas_detalhes vd ON v.order_id = vd.order_id
            WHERE v.order_id = '${dih.delta.order_id}'
+           AND v.status != -3
            GROUP BY v.order_id
         "
 

--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -89,7 +89,10 @@
         deltaQuery="
           SELECT v.order_id
           FROM vendas v
-          WHERE DATE_ADD(v.updated_at, INTERVAL 3 HOUR) &gt; '${dih.last_index_time}'
+          WHERE 
+            DATE_ADD(v.updated_at, INTERVAL 3 HOUR) &gt; '${dih.last_index_time}'
+          AND 
+            v.status != -3
         "
       >
 

--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -44,7 +44,7 @@
           JOIN vendas v ON vi.order_id = v.order_id
           LEFT JOIN vendas_detalhes vd ON v.order_id = vd.order_id
           WHERE v.log > DATE_SUB(NOW(), INTERVAL 6 MONTH)
-          AND v.status != -3
+          AND v.status != -4
           GROUP BY order_id"
 
         deltaImportQuery="
@@ -82,7 +82,7 @@
            JOIN vendas v ON vi.order_id = v.order_id
            LEFT JOIN vendas_detalhes vd ON v.order_id = vd.order_id
            WHERE v.order_id = '${dih.delta.order_id}'
-           AND v.status != -3
+           AND v.status != -4
            GROUP BY v.order_id
         "
 
@@ -92,7 +92,7 @@
           WHERE 
             DATE_ADD(v.updated_at, INTERVAL 3 HOUR) &gt; '${dih.last_index_time}'
           AND 
-            v.status != -3
+            v.status != -4
         "
       >
 


### PR DESCRIPTION
Esse PR visa esconder pedidos com status -3 do painel do livreiro.

Será necessário realizar um full import após o código ir para produção.