### PR TITLE
Adiciona KeywordTokenizer

### DIFF
--- a/solr-config/files/default/cores/library/conf/schema.xml
+++ b/solr-config/files/default/cores/library/conf/schema.xml
@@ -442,11 +442,13 @@
     <fieldType name="phrase" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.LowerCaseTokenizerFactory"/>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.LowerCaseTokenizerFactory"/>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
     </fieldType>
 

--- a/solr-config/files/default/cores/library/conf/schema.xml
+++ b/solr-config/files/default/cores/library/conf/schema.xml
@@ -118,10 +118,8 @@
    <field name="authors" type="text_general" indexed="true" stored="true" required="false" multiValued="true" termVectors="true" />
    <field name="authors_simple" type="text_general" indexed="true" stored="true" required="false" multiValued="true" termVectors="true" />
    <field name="s_authors" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-   <field name="authors_phrase" type="phrase" indexed="true" stored="true" required="false" multiValued="true" />
    <field name="title" type="text_general" indexed="true" stored="true" required="false" multiValued="false" termVectors="true" />
    <field name="title_simple" type="text_general" indexed="true" stored="true" required="false" multiValued="false" termVectors="true" />
-   <field name="title_phrase" type="phrase" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="volume" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="synopsis" type="text_general" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="cluster_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
@@ -267,9 +265,7 @@
    <copyField source="issn" dest="text"/>
 
    <copyField source="title" dest="title_simple"/>
-   <copyField source="title" dest="title_phrase"/>
 
-   <copyField source="authors" dest="authors_phrase"/>
    <copyField source="authors" dest="s_authors"/>
    <copyField source="authors" dest="authors_simple"/>
 
@@ -436,19 +432,6 @@
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- <filter class="solr.BrazilianStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-
-    <fieldType name="phrase" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
     </fieldType>
 

--- a/solr-config/files/default/cores/library/conf/schema.xml
+++ b/solr-config/files/default/cores/library/conf/schema.xml
@@ -118,10 +118,10 @@
    <field name="authors" type="text_general" indexed="true" stored="true" required="false" multiValued="true" termVectors="true" />
    <field name="authors_simple" type="text_general" indexed="true" stored="true" required="false" multiValued="true" termVectors="true" />
    <field name="s_authors" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-   <field name="authors_keyword" type="keyword" indexed="true" stored="true" required="false" multiValued="true" />
+   <field name="authors_phrase" type="phrase" indexed="true" stored="true" required="false" multiValued="true" />
    <field name="title" type="text_general" indexed="true" stored="true" required="false" multiValued="false" termVectors="true" />
    <field name="title_simple" type="text_general" indexed="true" stored="true" required="false" multiValued="false" termVectors="true" />
-   <field name="title_keyword" type="keyword" indexed="true" stored="true" required="false" multiValued="false" />
+   <field name="title_phrase" type="phrase" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="volume" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="synopsis" type="text_general" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="cluster_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
@@ -267,9 +267,9 @@
    <copyField source="issn" dest="text"/>
 
    <copyField source="title" dest="title_simple"/>
-   <copyField source="title" dest="title_keyword"/>
+   <copyField source="title" dest="title_phrase"/>
 
-   <copyField source="authors" dest="authors_keyword"/>
+   <copyField source="authors" dest="authors_phrase"/>
    <copyField source="authors" dest="s_authors"/>
    <copyField source="authors" dest="authors_simple"/>
 
@@ -439,16 +439,14 @@
       </analyzer>
     </fieldType>
 
-    <fieldType name="keyword" class="solr.TextField" positionIncrementGap="100">
+    <fieldType name="phrase" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
+        <tokenizer class="solr.LowerCaseTokenizerFactory"/>
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
+        <tokenizer class="solr.LowerCaseTokenizerFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr-config/files/default/cores/library/conf/schema.xml
+++ b/solr-config/files/default/cores/library/conf/schema.xml
@@ -118,10 +118,10 @@
    <field name="authors" type="text_general" indexed="true" stored="true" required="false" multiValued="true" termVectors="true" />
    <field name="authors_simple" type="text_general" indexed="true" stored="true" required="false" multiValued="true" termVectors="true" />
    <field name="s_authors" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-   <field name="authors_to_phrase" type="text_to_phrase" indexed="true" stored="true" required="false" multiValued="true" />
+   <field name="authors_keyword" type="keyword" indexed="true" stored="true" required="false" multiValued="true" />
    <field name="title" type="text_general" indexed="true" stored="true" required="false" multiValued="false" termVectors="true" />
    <field name="title_simple" type="text_general" indexed="true" stored="true" required="false" multiValued="false" termVectors="true" />
-   <field name="title_to_phrase" type="text_to_phrase" indexed="true" stored="true" required="false" multiValued="false" />
+   <field name="title_keyword" type="keyword" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="volume" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="synopsis" type="text_general" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="cluster_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
@@ -158,7 +158,7 @@
    <field name="pages" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="book_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="publication_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
-   <field name="publisher" type="text_ngram" indexed="true" stored="true" required="false" multiValued="false" />
+   <field name="publisher" type="text_general" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="s_publisher" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="publisher_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
    <field name="format" type="string" indexed="false" stored="true" required="false" multiValued="false" />
@@ -261,23 +261,24 @@
         or to add multiple fields to the same field for easier/faster searching.  -->
 
    <copyField source="title" dest="text"/>
-   <copyField source="title" dest="title_simple"/>
-   <copyField source="title" dest="title_to_phrase"/>
+   <copyField source="authors" dest="text"/>
+   <copyField source="volume" dest="text"/>
    <copyField source="isbn" dest="text"/>
    <copyField source="issn" dest="text"/>
+
+   <copyField source="title" dest="title_simple"/>
+   <copyField source="title" dest="title_keyword"/>
+
+   <copyField source="authors" dest="authors_keyword"/>
+   <copyField source="authors" dest="s_authors"/>
+   <copyField source="authors" dest="authors_simple"/>
+
+   <copyField source="publisher" dest="s_publisher"/>
 
    <!-- Para a busca por publicacao via ISBN, ISSN, Codigo de Barras -->
    <copyField source="isbn" dest="publication_search_field"/>
    <copyField source="issn" dest="publication_search_field"/>
    <copyField source="barcode" dest="publication_search_field"/>
-
-   <copyField source="authors" dest="authors_to_phrase"/>
-   <copyField source="authors" dest="s_authors"/>
-   <copyField source="authors" dest="authors_simple"/>
-   <copyField source="authors" dest="text"/>
-
-   <copyField source="publisher" dest="s_publisher"/>
-
 
   <!--
    <copyField source="body" dest="text"/>
@@ -438,26 +439,16 @@
       </analyzer>
     </fieldType>
 
-    <fieldType name="text_to_phrase" class="solr.TextField" positionIncrementGap="100">
+    <fieldType name="keyword" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <fieldType name="text_spell" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
       </analyzer>
     </fieldType>
 

--- a/solr-config/files/default/cores/library/conf/schema.xml
+++ b/solr-config/files/default/cores/library/conf/schema.xml
@@ -266,8 +266,8 @@
 
    <copyField source="title" dest="title_simple"/>
 
-   <copyField source="authors" dest="s_authors"/>
    <copyField source="authors" dest="authors_simple"/>
+   <copyField source="authors" dest="s_authors"/>
 
    <copyField source="publisher" dest="s_publisher"/>
 

--- a/solr-config/files/default/cores/library/conf/solrconfig.xml
+++ b/solr-config/files/default/cores/library/conf/solrconfig.xml
@@ -523,7 +523,7 @@
      <lst name="defaults">
        <str name="defType">edismax</str>
        <str name="qf">title authors volume^0.7 publisher^0.1 synopsis^0.1</str>
-       <str name="pf">title_keyword^5 authors_keyword^5</str>
+       <str name="pf">title_phrase^5 authors_phrase^5</str>
        <str name="ps">0</str>
        <str name="boost">sum(if(is_moderated,1,0.5),pow(unique_sellers_per_book,0.3),pow(sku_count,0.1))</str>
 

--- a/solr-config/files/default/cores/library/conf/solrconfig.xml
+++ b/solr-config/files/default/cores/library/conf/solrconfig.xml
@@ -523,7 +523,7 @@
      <lst name="defaults">
        <str name="defType">edismax</str>
        <str name="qf">title authors volume^0.7 publisher^0.1 synopsis^0.1</str>
-       <str name="pf">title_to_phrase^5 authors_to_phrase^5</str>
+       <str name="pf">title_keyword^5 authors_keyword^5</str>
        <str name="ps">0</str>
        <str name="boost">sum(if(is_moderated,1,0.5),pow(unique_sellers_per_book,0.3),pow(sku_count,0.1))</str>
 

--- a/solr-config/files/default/cores/library/conf/solrconfig.xml
+++ b/solr-config/files/default/cores/library/conf/solrconfig.xml
@@ -523,8 +523,6 @@
      <lst name="defaults">
        <str name="defType">edismax</str>
        <str name="qf">title authors volume^0.7 publisher^0.1 synopsis^0.1</str>
-       <str name="pf">title_phrase^5 authors_phrase^5</str>
-       <str name="ps">0</str>
        <str name="boost">sum(if(is_moderated,1,0.5),pow(unique_sellers_per_book,0.3),pow(sku_count,0.1))</str>
 
        <str name="echoParams">explicit</str>


### PR DESCRIPTION
Keyword Tokenizer does not split the input at all.
No processing in performed on the string, and the whole string is treated as a single entity.
This doesn't actually do any tokenization. It returns the original text as one term.

Mainly used for sorting or faceting requirements, where you want to match the exact facet when filtering on multiple words and sorting as sorting does not work on tokenized fields.