### PR TITLE
Acertar diferença de horário entre banco legado e Solr

### DIFF
--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -90,7 +90,7 @@
           SELECT v.order_id
           FROM vendas v
           WHERE 
-            DATE_ADD(v.updated_at, INTERVAL 3 HOUR) &gt; '${dih.last_index_time}'
+            DATE_ADD(v.updated_at, INTERVAL 7 HOUR) &gt; '${dih.last_index_time}'
           AND 
             v.status != -4
         "


### PR DESCRIPTION
Se alteramos uma venda pelo NCA às 14:11, o updated_at da mesma no banco do legado mostra 10:07. Ao rodarmos o delta import do Solr, essa venda não é indexada pois o updated_at + 3 horas (13:07) é menor que o horário que foi rodado o ultimo import (por exemplo 14:10).

Ao que tudo indica o horário do Solr ainda esta "adiantando" em 2 horas, sendo assim o horário real do ultimo import realizado pelo Solr seria 16:10.

Adicionei 7 horas ao horário do updated_at pois ainda temos os minutos que não estão totalmente sincronizados.