### PR TITLE
Melhorar tempo de resposta de query

### DIFF
--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -174,7 +174,7 @@
           SELECT v.order_id
           FROM vendas v
           WHERE
-            DATE_ADD(v.updated_at, INTERVAL 7 HOUR) &gt; '${dih.last_index_time}'
+            v.updated_at &gt; DATE_SUB('${dih.last_index_time}', INTERVAL 7 HOUR)
           AND
             v.status not in(-4,-9)
         "


### PR DESCRIPTION
Antes da alteração:

```
# Time: 190201 17:10:17
# User@Host: solr-sellerdeals[solr-sellerdeals] @  [10.0.0.103]  Id: 578798
# Query_time: 16.651305  Lock_time: 0.000078 Rows_sent: 9  Rows_examined: 27578353

SET timestamp=1549048217;

SELECT
	v.order_id
FROM
	vendas v
WHERE 
	DATE_ADD(v.updated_at, INTERVAL 7 HOUR) > '2019-02-01 19:08:02'
	AND v.status not in(-4,-9);
```

Após alteração:

```
# User@Host: solr-sellerdeals[solr-sellerdeals] @  [10.0.0.103]  Id: 578830
# Query_time: 0.000261  Lock_time: 0.000082 Rows_sent: 9  Rows_examined: 9

SET timestamp=1549048561;

SELECT
	v.order_id
FROM
	vendas v
WHERE
	v.updated_at > DATE_SUB('2019-02-01 19:14:01', INTERVAL 7 HOUR)
	AND v.status not in(-4,-9);
```