### PR TITLE
IN-29 | Passando a indexar pedidos com todos os status.

### DIFF
--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -173,8 +173,6 @@
           FROM vendas v
           WHERE
             v.updated_at &gt; DATE_SUB('${dih.last_index_time}', INTERVAL 7 HOUR)
-          AND
-            v.status not in(-4,-9)
         "
       >
 

--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -86,7 +86,6 @@
           LEFT JOIN vendas_taxas vt ON v.order_id = vt.order_id
           LEFT JOIN usuarios vu ON vu.user_id = v.comprador
           WHERE v.log > DATE_SUB(NOW(), INTERVAL 6 MONTH)
-          AND v.status not in(-4,-9)
           GROUP BY order_id"
 
         deltaImportQuery="
@@ -166,7 +165,6 @@
            LEFT JOIN vendas_taxas vt ON v.order_id = vt.order_id
            LEFT JOIN usuarios vu ON vu.user_id = v.comprador
            WHERE v.order_id = '${dih.delta.order_id}'
-           AND v.status not in(-4,-9)
            GROUP BY v.order_id
         "
 


### PR DESCRIPTION
# Tickets no Merge Request

[IN-29 | Resolver problema dos pedidos com status -9 aparecenrem no Painel do Livreiro](https://estantevirtual.atlassian.net/browse/IN-29)

## Resumo:

Alguns pedidos que estão no banco de dados na tabela `vendas` com status -9 estão aparecendo no Painel do Livreiro, contudo lá eles estão com status 1. -1. Isso acontece porque o Solr não indexa pedidos com status -9 (e nem -4), portanto ele fica eternamente preso num estado anterior, inclusive aparecendo no Painel do Livreiro indevidamente.

Para resolver esse problema, vamos indexar pedidos com todos os status, e filtrar o status do pedido na query.

## Lista de Checagem:

- [x] Fez um teste manual de fluxo para validar que foi feito o que foi solitado?

## Como testar

Faça uma consulta ao Solr por um pedido com status -4 ou -9, e verifique se ele é retornado.