### PR TITLE
Restrição a IPs Externos

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -1,3 +1,7 @@
+set_real_ip_from  10.0.0.0/16;
+real_ip_header    X-Forwarded-For;
+real_ip_recursive on;
+
 upstream unicorn_<%= @application[:domains].first %> {
  server unix:<%= @application[:deploy_to]%>/shared/sockets/unicorn.sock fail_timeout=0;
 }
@@ -36,9 +40,15 @@ server {
     }
   }
 
+  <% if node[:nginx] && node[:nginx][:internal_only] %>
+  location <%= node[:nginx][:internal_only][:location] %> {
+    allow <%= node[:nginx][:internal_only][:allow] || '10.0.0.0/8' %>;
+    deny all;
+    try_files $uri/index.html $uri/index.htm @unicorn;
+  }
+  <% end %>
 
-
-  location @unicorn {
+location @unicorn {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;


### PR DESCRIPTION
Adicionando configuração parametrizável, para bloquear requisições externas em determinadas URLs.