### PR TITLE
Vend 1372 - Alterar retorno do nome da transportadora quando não tiver registro na tabela de transportadoras

### DIFF
--- a/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
+++ b/solr-config/templates/default/cores/seller_deals/data-config.xml.erb
@@ -76,7 +76,7 @@
             v.link_de_rastreio AS 'shipping_tracking_url',
             CASE
               WHEN t2.nome != '' THEN t2.nome
-              ELSE ''
+              ELSE 'correios'
              END AS carrier,
 
             GROUP_CONCAT(vi.autor, '#-#', vi.titulo, '#-#', coalesce(vi.editora,''), '#-#', coalesce(vi.book_type,'0'), '#-#',
@@ -161,7 +161,7 @@
              v.link_de_rastreio AS 'shipping_tracking_url',
              CASE
               WHEN t2.nome != '' THEN t2.nome
-              ELSE ''
+              ELSE 'correios'
              END AS carrier,
              GROUP_CONCAT(vi.autor, '#-#', vi.titulo, '#-#', coalesce(vi.editora,''), '#-#', coalesce(vi.book_type,'0'), '#-#',
                           coalesce(vi.idioma, ''), '#-#', coalesce(location_in_store,' '), '#-#', coalesce(category, ' '),'#-#',


### PR DESCRIPTION
# Tickets no Merge Request

[Vend 1372 - Alterar retorno do nome da transportadora quando não tiver registro na tabela de transportadoras](https://estantevirtual.atlassian.net/secure/RapidBoard.jspa?rapidView=107&projectKey=VEND&modal=detail&selectedIssue=VEND-1372) 

## Resumo:

Foi solicitado que quando não houver transportadora envolvida na entrega do pedido, que o campo carrier seja retornado como "correios", para facilitar o filtro no painel do livreiro de modo a ser possível filtrar pedidos que não sejam de nenhuma transportadora.

## Lista de Checagem:

- [x] Fez um teste manual de fluxo para validar que foi feito o que foi solitado?

## Como testar
Acessar o Solr e faz o filtro pelo campo carrier, sendo que quando preenche com `carrier:correios` não pode trazer nenhum pedido que tenha carrier como magalu_entregas. Quando preencher `carrier:*` tem que trazer todos os pedidos.